### PR TITLE
Allow setting of replacement flags in publication.

### DIFF
--- a/pydbus/publication.py
+++ b/pydbus/publication.py
@@ -37,6 +37,6 @@ class Publication(ExitableWithAliases("unpublish")):
 class PublicationMixin(object):
 	__slots__ = ()
 
-	def publish(self, bus_name, *objects):
+	def publish(self, bus_name, *objects, **kwargs):
 		"""Expose objects on the bus."""
-		return Publication(self, bus_name, *objects)
+		return Publication(self, bus_name, *objects, **kwargs)

--- a/tests/publish_replacable.py
+++ b/tests/publish_replacable.py
@@ -1,0 +1,53 @@
+from pydbus import SessionBus
+from gi.repository import GLib
+from threading import Thread
+import sys
+
+loop = GLib.MainLoop()
+
+bus = SessionBus()
+
+class TestObject(object):
+    '''
+<node>
+    <interface name='net.lew21.pydbus.tests.publish_replacable'>
+        <method name='Id'>
+            <arg type='s' name='id' direction='out'/>
+        </method>
+        <method name='Quit'/>
+    </interface>
+</node>
+    '''
+    def __init__(self, id):
+        self.id = id
+        dbus = bus.get('org.freedesktop.DBus', '/org/freedesktop/DBus')
+        dbus.NameLost.connect(self._handle_replacement_cb)
+
+    def Id(self):
+        res = self.id
+        print("%s: Id() called" % res)
+        return res
+
+    def Quit(self):
+        print("%s: quitting" % self.id)
+        GLib.timeout_add_seconds(1, loop.quit)
+
+    def _handle_replacement_cb(self, name):
+        if name == "net.lew21.pydbus.tests.publish_replacable":
+            print("%s: replaced" % self.id)
+            self.Quit()
+
+with bus.publish("net.lew21.pydbus.tests.publish_replacable", TestObject("Old Owner"), allow_replacement=True):
+    remote = bus.get("net.lew21.pydbus.tests.publish_replacable")
+
+    def t1_func():
+        remote.Id()
+
+    t1 = Thread(None, t1_func)
+    t1.daemon = True
+
+    t1.start()
+
+    loop.run()
+
+    t1.join()

--- a/tests/publish_replace.py
+++ b/tests/publish_replace.py
@@ -1,0 +1,55 @@
+from pydbus import SessionBus
+from gi.repository import GLib
+from threading import Thread
+import sys
+import time
+
+loop = GLib.MainLoop()
+
+bus = SessionBus()
+
+SERVICE_NAME = "net.lew21.pydbus.tests.publish_replacable"
+
+class TestObject(object):
+    '''
+<node>
+    <interface name='net.lew21.pydbus.tests.publish_replacable'>
+        <method name='Id'>
+            <arg type='s' name='id' direction='out'/>
+        </method>
+        <method name='Quit'/>
+    </interface>
+</node>
+    '''
+    def __init__(self, id):
+        self.id = id
+
+    def Id(self):
+        res = self.id
+        print("%s: Id() called" % res)
+        return res
+
+    def Quit(self):
+        print("%s: quitting" % self.id)
+        GLib.timeout_add_seconds(1, loop.quit)
+
+time.sleep(2)
+remote = bus.get(SERVICE_NAME)
+id = remote.Id()
+assert(id == "Old Owner")
+
+with bus.publish(SERVICE_NAME, TestObject("New Owner"), replace=True):
+
+    def t1_func():
+        id = remote.Id()
+        assert(id == "New Owner")
+        remote.Quit()
+
+    t1 = Thread(None, t1_func)
+    t1.daemon = True
+
+    t1.start()
+
+    loop.run()
+
+    t1.join()

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -18,4 +18,8 @@ then
 	"$PYTHON" $TESTS_DIR/publish_multiface.py
 	"$PYTHON" $TESTS_DIR/publish_async.py
 	"$PYTHON" $TESTS_DIR/publish_error.py
+	# service replacement test START
+	"$PYTHON" $TESTS_DIR/publish_replacable.py &
+	"$PYTHON" $TESTS_DIR/publish_replace.py
+	# service replacement test END
 fi


### PR DESCRIPTION
Would it be better to add explicit keyword arguments to publish?
Perhaps should be also documented, at least in the publish docstring.
