### PR TITLE
Support for asynchronous calls and error transformation

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -341,6 +341,53 @@ See ``help(bus.request_name)`` and ``help(bus.register_object)`` for details.
 
 .. --------------------------------------------------------------------
 
+Error handling
+==============
+
+You can map D-Bus errors to your exception classes for better error handling.
+To handle D-Bus errors, use the ``@map_error`` decorator::
+
+    from pydbus.error import map_error
+
+    @map_error("org.freedesktop.DBus.Error.InvalidArgs")
+    class InvalidArgsException(Exception):
+        pass
+
+    try:
+        ...
+    catch InvalidArgsException as e:
+        print(e)
+
+To register new D-Bus errors, use the ``@register_error`` decorator::
+
+    from pydbus.error import register_error
+
+    @map_error("net.lew21.pydbus.TutorialExample.MyError", MY_DOMAIN, MY_EXCEPTION_CODE)
+    class MyException(Exception):
+        pass
+
+Then you can raise ``MyException`` from the D-Bus method of the remote object::
+
+    def Method():
+        raise MyException("Message")
+
+And catch the same exception on the client side::
+
+    try:
+        proxy.Method()
+    catch MyException as e:
+        print(e)
+
+To handle all unknown D-Bus errors, use the ``@map_by_default`` decorator to specify the default exception::
+
+    from pydbus.error import map_by_default
+
+    @map_by_default
+    class DefaultException(Exception):
+        pass
+
+.. --------------------------------------------------------------------
+
 Data types
 ==========
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -84,7 +84,8 @@ All objects have methods, properties and signals.
 Setting up an event loop
 ========================
 
-To handle signals emitted by exported objects, or to export your own objects, you need to setup an event loop.
+To handle signals emitted by exported objects, to asynchronously call methods
+or to export your own objects, you need to setup an event loop.
 
 The only main loop supported by ``pydbus`` is GLib.MainLoop.
 
@@ -155,6 +156,14 @@ To see the API of a specific proxy object, use help()::
 To call a method::
 
     dev.Disconnect()
+
+To asynchronously call a method::
+
+    def print_result(returned=None, error=None):
+        print(returned, error)
+
+    dev.GetAppliedConnection(0, callback=print_result)
+    loop.run()
 
 To read a property::
 

--- a/pydbus/error.py
+++ b/pydbus/error.py
@@ -1,0 +1,97 @@
+from gi.repository import GLib, Gio
+
+
+def register_error(name, domain, code):
+	"""Register and map decorated exception class to a DBus error."""
+	def decorated(cls):
+		error_registration.register_error(cls, name, domain, code)
+		return cls
+
+	return decorated
+
+
+def map_error(error_name):
+	"""Map decorated exception class to a DBus error."""
+	def decorated(cls):
+		error_registration.map_error(cls, error_name)
+		return cls
+
+	return decorated
+
+
+def map_by_default(cls):
+	"""Map decorated exception class to all unknown DBus errors."""
+	error_registration.map_by_default(cls)
+	return cls
+
+
+class ErrorRegistration(object):
+	"""Class for mapping exceptions to DBus errors."""
+
+	_default = None
+	_map = dict()
+	_reversed_map = dict()
+
+	def map_by_default(self, exception_cls):
+		"""Set the exception class as a default."""
+		self._default = exception_cls
+
+	def map_error(self, exception_cls, name):
+		"""Map the exception class to a DBus name."""
+		self._map[name] = exception_cls
+		self._reversed_map[exception_cls] = name
+
+	def register_error(self, exception_cls, name, domain, code):
+		"""Map and register the exception class to a DBus name."""
+		self.map_error(exception_cls, name)
+		return Gio.DBusError.register_error(domain, code, name)
+
+	def is_registered_exception(self, obj):
+		"""Is the exception registered?"""
+		return obj.__class__ in self._reversed_map
+
+	def get_dbus_name(self, obj):
+		"""Get the DBus name of the exception."""
+		return self._reversed_map.get(obj.__class__)
+
+	def get_exception_class(self, name):
+		"""Get the exception class mapped to the DBus name."""
+		return self._map.get(name, self._default)
+
+	def transform_message(self, name, message):
+		"""Transform the message of the exception."""
+		prefix = "{}:{}: ".format("GDBus.Error", name)
+
+		if message.startswith(prefix):
+			return message[len(prefix):]
+
+		return message
+
+	def transform_exception(self, e):
+		"""Transform the remote error to the exception."""
+		if not isinstance(e, GLib.Error):
+			return e
+
+		if not Gio.DBusError.is_remote_error(e):
+			return e
+
+		# Get DBus name of the error.
+		name = Gio.DBusError.get_remote_error(e)
+		# Get the exception class.
+		exception_cls = self.get_exception_class(name)
+
+		# Return the original exception.
+		if not exception_cls:
+			return e
+
+		# Return new exception.
+		message = self.transform_message(name, e.message)
+		exception = exception_cls(message)
+		exception.dbus_name = name
+		exception.dbus_domain = e.domain
+		exception.dbus_code = e.code
+		return exception
+
+
+# Default error registration.
+error_registration = ErrorRegistration()

--- a/tests/error.py
+++ b/tests/error.py
@@ -1,0 +1,67 @@
+from pydbus.error import ErrorRegistration
+
+
+class ExceptionA(Exception):
+	pass
+
+
+class ExceptionB(Exception):
+	pass
+
+
+class ExceptionC(Exception):
+	pass
+
+
+class ExceptionD(Exception):
+	pass
+
+
+class ExceptionE(Exception):
+	pass
+
+
+def test_error_mapping():
+	r = ErrorRegistration()
+	r.map_error(ExceptionA, "net.lew21.pydbus.tests.ErrorA")
+	r.map_error(ExceptionB, "net.lew21.pydbus.tests.ErrorB")
+	r.map_error(ExceptionC, "net.lew21.pydbus.tests.ErrorC")
+
+	assert r.is_registered_exception(ExceptionA("Test"))
+	assert r.is_registered_exception(ExceptionB("Test"))
+	assert r.is_registered_exception(ExceptionC("Test"))
+	assert not r.is_registered_exception(ExceptionD("Test"))
+	assert not r.is_registered_exception(ExceptionE("Test"))
+
+	assert r.get_dbus_name(ExceptionA("Test")) == "net.lew21.pydbus.tests.ErrorA"
+	assert r.get_dbus_name(ExceptionB("Test")) == "net.lew21.pydbus.tests.ErrorB"
+	assert r.get_dbus_name(ExceptionC("Test")) == "net.lew21.pydbus.tests.ErrorC"
+
+	assert r.get_exception_class("net.lew21.pydbus.tests.ErrorA") == ExceptionA
+	assert r.get_exception_class("net.lew21.pydbus.tests.ErrorB") == ExceptionB
+	assert r.get_exception_class("net.lew21.pydbus.tests.ErrorC") == ExceptionC
+	assert r.get_exception_class("net.lew21.pydbus.tests.ErrorD") is None
+	assert r.get_exception_class("net.lew21.pydbus.tests.ErrorE") is None
+
+	r.map_by_default(ExceptionD)
+	assert not r.is_registered_exception(ExceptionD("Test"))
+	assert r.get_exception_class("net.lew21.pydbus.tests.ErrorD") == ExceptionD
+	assert r.get_exception_class("net.lew21.pydbus.tests.ErrorE") == ExceptionD
+
+
+def test_transform_message():
+	r = ErrorRegistration()
+	n1 = "net.lew21.pydbus.tests.ErrorA"
+	m1 = "GDBus.Error:net.lew21.pydbus.tests.ErrorA: Message1"
+
+	n2 = "net.lew21.pydbus.tests.ErrorB"
+	m2 = "GDBus.Error:net.lew21.pydbus.tests.ErrorB: Message2"
+
+	assert r.transform_message(n1, m1) == "Message1"
+	assert r.transform_message(n2, m2) == "Message2"
+	assert r.transform_message(n1, m2) == m2
+	assert r.transform_message(n2, m1) == m1
+
+
+test_error_mapping()
+test_transform_message()

--- a/tests/publish_async.py
+++ b/tests/publish_async.py
@@ -1,0 +1,63 @@
+from pydbus import SessionBus
+from gi.repository import GLib
+from threading import Thread
+import sys
+
+done = 0
+loop = GLib.MainLoop()
+
+class TestObject(object):
+	'''
+<node>
+	<interface name='net.lew21.pydbus.tests.publish_async'>
+		<method name='HelloWorld'>
+			<arg type='i' name='x' direction='in'/>
+			<arg type='s' name='response' direction='out'/>
+		</method>
+	</interface>
+</node>
+	'''
+	def __init__(self, id):
+		self.id = id
+
+	def HelloWorld(self, x):
+		res = self.id + ": " + str(x)
+		print(res)
+		return res
+
+bus = SessionBus()
+
+with bus.publish("net.lew21.pydbus.tests.publish_async", TestObject("Obj")):
+	remote = bus.get("net.lew21.pydbus.tests.publish_async")
+
+	def callback(x, returned=None, error=None):
+		print("asyn: " + returned)
+		assert (returned is not None)
+		assert(error is None)
+		assert(x == int(returned.split()[1]))
+
+		global done
+		done += 1
+		if done == 3:
+			loop.quit()
+
+	def t1_func():
+		remote.HelloWorld(1, callback=callback, callback_args=(1,))
+		remote.HelloWorld(2, callback=callback, callback_args=(2,))
+		print("sync: " + remote.HelloWorld(3))
+		remote.HelloWorld(4, callback=callback, callback_args=(4,))
+
+	t1 = Thread(None, t1_func)
+	t1.daemon = True
+
+	def handle_timeout():
+		print("ERROR: Timeout.")
+		sys.exit(1)
+
+	GLib.timeout_add_seconds(2, handle_timeout)
+
+	t1.start()
+
+	loop.run()
+
+	t1.join()

--- a/tests/publish_error.py
+++ b/tests/publish_error.py
@@ -1,0 +1,132 @@
+import sys
+from threading import Thread
+from gi.repository import GLib, Gio
+from pydbus import SessionBus
+from pydbus.error import register_error, map_error, map_by_default, error_registration
+
+import logging
+logger = logging.getLogger('pydbus.registration')
+logger.disabled = True
+
+loop = GLib.MainLoop()
+DOMAIN = Gio.DBusError.quark()  # TODO: Register new domain.
+
+
+@register_error("net.lew21.pydbus.tests.ErrorA", DOMAIN, 1000)
+class ExceptionA(Exception):
+	pass
+
+
+@register_error("net.lew21.pydbus.tests.ErrorB", DOMAIN, 2000)
+class ExceptionB(Exception):
+	pass
+
+
+@map_error("org.freedesktop.DBus.Error.InvalidArgs")
+class ExceptionC(Exception):
+	pass
+
+
+@map_by_default
+class ExceptionD(Exception):
+	pass
+
+
+class ExceptionE(Exception):
+	pass
+
+
+class TestObject(object):
+	'''
+<node>
+	<interface name='net.lew21.pydbus.tests.TestInterface'>
+		<method name='RaiseA'>
+			<arg type='s' name='msg' direction='in'/>
+		</method>
+		<method name='RaiseB'>
+			<arg type='s' name='msg' direction='in'/>
+		</method>
+		<method name='RaiseD'>
+			<arg type='s' name='msg' direction='in'/>
+		</method>
+		<method name='RaiseE'>
+			<arg type='s' name='msg' direction='in'/>
+		</method>
+	</interface>
+</node>
+	'''
+
+	def RaiseA(self, msg):
+		raise ExceptionA(msg)
+
+	def RaiseB(self, msg):
+		raise ExceptionB(msg)
+
+	def RaiseD(self, msg):
+		raise ExceptionD(msg)
+
+	def RaiseE(self, msg):
+		raise ExceptionE(msg)
+
+bus = SessionBus()
+
+with bus.publish("net.lew21.pydbus.tests.Test", TestObject()):
+	remote = bus.get("net.lew21.pydbus.tests.Test")
+
+	def t_func():
+		# Test new registered errors.
+		try:
+			remote.RaiseA("Test A")
+		except ExceptionA as e:
+			assert str(e) == "Test A"
+
+		try:
+			remote.RaiseB("Test B")
+		except ExceptionB as e:
+			assert str(e) == "Test B"
+
+		# Test mapped errors.
+		try:
+			remote.Get("net.lew21.pydbus.tests.TestInterface", "Foo")
+		except ExceptionC as e:
+			assert str(e) == "No such property 'Foo'"
+
+		# Test default errors.
+		try:
+			remote.RaiseD("Test D")
+		except ExceptionD as e:
+			assert str(e) == "Test D"
+
+		try:
+			remote.RaiseE("Test E")
+		except ExceptionD as e:
+			assert str(e) == "Test E"
+
+		# Test with no default errors.
+		error_registration.map_by_default(None)
+
+		try:
+			remote.RaiseD("Test D")
+		except Exception as e:
+			assert not isinstance(e, ExceptionD)
+
+		try:
+			remote.RaiseE("Test E")
+		except Exception as e:
+			assert not isinstance(e, ExceptionD)
+			assert not isinstance(e, ExceptionE)
+
+		loop.quit()
+
+	t = Thread(None, t_func)
+	t.daemon = True
+
+	def handle_timeout():
+		print("ERROR: Timeout.")
+		sys.exit(1)
+
+	GLib.timeout_add_seconds(4, handle_timeout)
+
+	t.start()
+	loop.run()
+	t.join()

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -15,4 +15,5 @@ then
 	"$PYTHON" $TESTS_DIR/publish.py
 	"$PYTHON" $TESTS_DIR/publish_properties.py
 	"$PYTHON" $TESTS_DIR/publish_multiface.py
+	"$PYTHON" $TESTS_DIR/publish_async.py
 fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -10,10 +10,12 @@ PYTHON=${1:-python}
 
 "$PYTHON" $TESTS_DIR/context.py
 "$PYTHON" $TESTS_DIR/identifier.py
+"$PYTHON" $TESTS_DIR/error.py
 if [ "$2" != "dontpublish" ]
 then
 	"$PYTHON" $TESTS_DIR/publish.py
 	"$PYTHON" $TESTS_DIR/publish_properties.py
 	"$PYTHON" $TESTS_DIR/publish_multiface.py
 	"$PYTHON" $TESTS_DIR/publish_async.py
+	"$PYTHON" $TESTS_DIR/publish_error.py
 fi


### PR DESCRIPTION
Added support for asynchronous calls of methods. A method is called
synchronously unless its callback parameter is specified. A callback
is a function f(*args, returned=None, error=None), where args is
callback_args specified in the method call, returned is a return
value of the method and error is an exception raised by the method.

Example of an asynchronous call:
```
def func(x, y, returned=None, error=None):
  pass

proxy.Method(a, b, callback=func, callback_args=(x, y))
```

Exceptions can be registered with decorators, raised in a remote
method and recreated after return from the remote call.